### PR TITLE
Skip postinstall binary download when running in the repo itself

### DIFF
--- a/install.ts
+++ b/install.ts
@@ -101,6 +101,12 @@ function getSysInfo(): { arch: BinaryConfig['arch'], platform: BinaryConfig['pla
 
 (async () => {
     try {
+        // Skip install when running in the repo itself (e.g. during local `npm i` / `bun i`).
+        // When installed as a dependency, __dirname will be inside a node_modules folder.
+        if (!__dirname.includes('node_modules')) {
+          return;
+        }
+
         const { arch, platform, extension } = getSysInfo();
     
         const downloader = new BinaryDownloader({


### PR DESCRIPTION
When running `npm i` or `bun i` in the repo during development, the postinstall script would attempt to download the binary unnecessarily. This skips the download when __dirname is not inside node_modules, which means the package is not installed as a dependency.