### PR TITLE
DX-2555: switch to OIDC auth with provenance for npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   release:
     name: Release
@@ -14,7 +18,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set env
-        run: echo "VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        run: echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -30,15 +40,10 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Set NPM_TOKEN
-        run: npm set "//registry.npmjs.org/:_authToken" ${{ secrets.NPM_TOKEN }}
+      - name: Publish release candidate
+        if: "github.event.release.prerelease"
+        run: npm publish --access public --tag=canary --provenance
 
       - name: Publish
         if: "!github.event.release.prerelease"
-        run: |
-          npm publish --access public
-
-      - name: Publish release candidate
-        if: "github.event.release.prerelease"
-        run: |
-          npm publish --access public --tag=canary
+        run: npm publish --access public --provenance

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
     "qstash-cli": "./bin/qstash",
     "qstash": "./bin/qstash"
   },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:upstash/qstash-cli.git"
+  },
   "author": "",
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
Replace manual NPM_TOKEN with OIDC-based authentication via setup-node@v4, add --provenance flag for supply chain security, and fix version tag stripping.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>